### PR TITLE
setting deviceManufacturer property

### DIFF
--- a/src/main/java/com/thoughtworks/device/Device.java
+++ b/src/main/java/com/thoughtworks/device/Device.java
@@ -62,6 +62,7 @@ public class Device {
         this.deviceModel = deviceJson.getString("deviceModel");
         this.screenSize = deviceJson.getString("screenSize");
         this.os = deviceJson.getString("os");
+        this.deviceManufacturer=deviceJson.getString("deviceManufacturer");
     }
 
     public Device() {


### PR DESCRIPTION
setting deviceManufacturer property to avoid the null pointer while getting video logs in ATD